### PR TITLE
remove validity test in Socket::move op=

### DIFF
--- a/include/yael/network/Socket.h
+++ b/include/yael/network/Socket.h
@@ -116,9 +116,6 @@ private:
 
         void operator=(internal_message_in_t &&other)
         {
-            if(!other.valid())
-                throw std::runtime_error("other's not valid");
-
             length = other.length;
             read_pos = other.read_pos;
             data = other.data;

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -382,7 +382,7 @@ void Socket::pull_messages()
             m_messages.push_back(msg);
             received_full_msg = true;
 
-            m_has_current_message = false;
+            m_has_current_message = false;  // FIXME: remove this? it has already been false here.
         }
     }
 


### PR DESCRIPTION
the validity test only checks if `Socket::data` is `nullptr`,
but there are cases where the header hasn't been read thus
`data` has not yet been allocated.

maybe consider adding a boolean field marking the header has
been read?